### PR TITLE
Disable parallel builds for now

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -6,7 +6,8 @@ REM %2 can be "products" to just do the products directory
 
 for %%i in ( mvn.cmd ) do set "M2_HOME=%%~dp$PATH:i.."
 
-set "MY_ARGS=-T 1C clean verify"
+REM removed "-T 1C" from mvn while checking if it is cause of file in use errors in .m2 cache 
+set "MY_ARGS=clean verify"
 if /i "%1" == "noclean" (
     set "MY_ARGS=verify"
 )


### PR DESCRIPTION
These may be cause of "The process cannot access the file because it is being used by another process" with .lock files in .m2 repository